### PR TITLE
Upgrade Django to 1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,18 @@ ENV PREFIX /agentexoplanet
 
 # install and update packages
 RUN yum -y install epel-release \
-        && yum -y install gcc make mysql-devel python-devel python-pip uwsgi-plugin-python nginx supervisor \
+        && yum -y install gcc make mysql-devel python-devel python-pip nginx supervisor \
         && yum -y update \
         && yum -y clean all
 
 COPY app/requirements.txt /var/www/apps/agentexoplanet/requirements.txt
 
 # install Python packages
-RUN pip install --upgrade pip \
+RUN pip install --upgrade pip setuptools \
         && pip install -r /var/www/apps/agentexoplanet/requirements.txt \
         && rm -rf /root/.pip /root/.cache
+
+RUN useradd uwsgi && gpasswd -a uwsgi uwsgi
 
 # copy configuration files
 COPY config/uwsgi.ini /etc/uwsgi.ini

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,4 @@
-Django>1.10,<1.11
+Django>1.11,<1.12
 MySQL-python
 numpy
 astropy

--- a/config/uwsgi.ini
+++ b/config/uwsgi.ini
@@ -9,7 +9,6 @@ socket=0.0.0.0:9090
 buffer-size=32768
 harakiri=30
 processes=4
-plugins=python
 enable-threads=true
 single-interpreter=true
 thunder-lock=true


### PR DESCRIPTION
Upgrades Django to 1.12 (which also fixes a security vulnerability)
changes were tested locally by running the container with proper env
variables. Also changes some config items that were preventing the
container from starting.